### PR TITLE
Add sourcesContent array to source map

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
-var through = require('through2');
-var path = require('path');
 var convertSourceMap = require('convert-source-map');
+var fs = require('fs')
+var path = require('path');
+var through = require('through2');
 
 var cwd = process.cwd();
 
@@ -29,6 +30,15 @@ module.exports = function(filename, options) {
         function getCode() {
             if (smap) {
                 smap.setProperty('sourceRoot', getRoot(cwd, filename, smap));
+
+                var relativePath = path.relative(cwd, path.resolve(path.dirname(filename)))
+                var sources = smap.getProperty('sources')
+                if (sources && sources.length) {
+                    smap.setProperty('sourcesContent', sources.map(source => {
+                        var sourceFilename = path.resolve(relativePath, source)
+                        return fs.readFileSync(sourceFilename, 'utf8')
+                    }));
+                }
 
                 return convertSourceMap.removeMapFileComments(source) + smap.toComment();
             } else {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var convertSourceMap = require('convert-source-map');
-var fs = require('fs')
+var fs = require('fs');
 var path = require('path');
 var through = require('through2');
 
@@ -32,11 +32,11 @@ module.exports = function(filename, options) {
                 smap.setProperty('sourceRoot', getRoot(cwd, filename, smap));
 
                 var relativePath = path.relative(cwd, path.resolve(path.dirname(filename)))
-                var sources = smap.getProperty('sources')
+                var sources = smap.getProperty('sources');
                 if (sources && sources.length) {
                     smap.setProperty('sourcesContent', sources.map(source => {
-                        var sourceFilename = path.resolve(relativePath, source)
-                        return fs.readFileSync(sourceFilename, 'utf8')
+                        var sourceFilename = path.resolve(relativePath, source);
+                        return fs.readFileSync(sourceFilename, 'utf8');
                     }));
                 }
 


### PR DESCRIPTION
Fixes #1 - but I would advise further testing to make sure nothing breaks on different configurations. I was able to get the source content of my TypeScript libraries to show up. I played a little with the debugger in Firefox and it seems to be working.

After reading through issues #1 and browserify/browserify#772, I started looking into the source code of `browserify`. As mentioned [here](https://github.com/browserify/browserify/issues/772#issuecomment-96079578), `browserify` uses `browser-pack` module for generating source maps, which in turn uses the `combine-source-map` module.

After further digging, I realized the `Combiner.prototype.addFile` method in `node_modules/combine-source-map/index.js` has the following documentation written in the comments:

> Adds map to underlying source map. If source contains a source map comment that has the source of the original file inlined it will offset these mappings and include them. If no source map comment is found or it has no source inlined, mappings for the file will be generated and included

The `addFile` method then uses the `hasInlinedSource` function to check if there are any inlined source files - basically it checks if the `sourcesContent` array is present in the source map.

This change adds the `sourcesContent` property by reading through the original (in my case TypeScript) source files, as defined in the `sources` array. For this to work, I had to use a global browserify transform (`-g [ sourceify ]` CLI argument).

In the future, there could maybe be an option to ignore files from certain folders (like `ignore` for `babelify`) to improve performance.

<img src="https://user-images.githubusercontent.com/1489493/54882256-14f0df80-4e93-11e9-9d06-769447008c35.png">